### PR TITLE
Add storage.puml for UML representation

### DIFF
--- a/src/main/resources/UML/Storage.puml
+++ b/src/main/resources/UML/Storage.puml
@@ -1,0 +1,50 @@
+@startuml
+
+package "Storage" {
+
+    interface Storage <<interface>>
+
+    package "AddressBook Storage" {
+        interface AddressBookStorage <<interface>>
+        class JsonAddressBookStorage
+        class JsonSerializableAddressBook
+        class JsonAdaptedPerson
+        class JsonAdaptedTag
+    }
+
+    package "UserPrefs Storage" {
+        interface UserPrefsStorage <<interface>>
+        class JsonUserPrefsStorage
+    }
+
+    package "Team Storage" {
+        interface TeamBookStorage <<interface>>
+        class JsonTeamBookStorage
+        class JsonSerializableTeamBook
+        class JsonAdaptedTeam
+    }
+
+    class StorageManager
+
+    Storage <|-- AddressBookStorage
+    Storage <|-- UserPrefsStorage
+    Storage <|-- TeamBookStorage
+
+    AddressBookStorage <|.. JsonAddressBookStorage: 1
+    JsonAddressBookStorage --> JsonSerializableAddressBook
+    JsonSerializableAddressBook --> JsonAdaptedPerson: *
+    JsonSerializableAddressBook --> JsonAdaptedTag: *
+
+    UserPrefsStorage <|.. JsonUserPrefsStorage: 1
+
+    TeamBookStorage <|.. JsonTeamBookStorage: 1
+    JsonTeamBookStorage --> JsonSerializableTeamBook
+    JsonSerializableTeamBook --> JsonAdaptedTeam: *
+
+    StorageManager --> AddressBookStorage
+    StorageManager --> UserPrefsStorage
+    StorageManager --> TeamBookStorage
+
+}
+
+@enduml


### PR DESCRIPTION
The project lacked a visual representation of the storage component's architecture.

Having a UML diagram aids developers in understanding the structural relationships between storage classes and interfaces.

Let's introduce a PlantUML file named `storage.puml` that provides a detailed UML diagram for the storage component of the project.

Using PlantUML allows for easy updates to the diagram in future iterations, ensuring maintainability and clarity for the development team.