### PR TITLE
Fix grammar errors in output of FindCommand class and FindTeamCommand class

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -26,7 +26,10 @@ public class Messages {
 
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
+    public static final String MESSAGE_PERSON_LISTED_OVERVIEW = "%1$d person listed!";
+
     public static final String MESSAGE_TEAMS_LISTED_OVERVIEW = "%1$d teams listed!";
+    public static final String MESSAGE_TEAM_LISTED_OVERVIEW = "%1$d team listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -30,6 +30,11 @@ public class FindCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(predicate);
+        if (model.getFilteredPersonList().size() <= 1) {
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_PERSON_LISTED_OVERVIEW, model.getFilteredPersonList().size()),
+                    false, false, false, false, false, true, false);
+        }
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()),
                 false, false, false, false, false, true, false);

--- a/src/main/java/seedu/address/logic/commands/FindTeamCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindTeamCommand.java
@@ -31,6 +31,11 @@ public class FindTeamCommand extends Command {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         model.updateFilteredTeamList(predicate);
+        if (model.getFilteredTeamList().size() <= 1) {
+            return new CommandResult(
+                    String.format(Messages.MESSAGE_TEAM_LISTED_OVERVIEW, model.getFilteredTeamList().size()),
+                    false, false, false, false, false, false, true);
+        }
         return new CommandResult(
                 String.format(Messages.MESSAGE_TEAMS_LISTED_OVERVIEW, model.getFilteredTeamList().size()),
                 false, false, false, false, false, false, true);

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.CARL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalTeams.getTypicalTeamBook;
 
@@ -56,7 +57,7 @@ public class FindCommandTest {
 
     @Test
     public void execute_zeroKeywords_noPersonFound() {
-        String expectedMessage = "0 persons listed!";
+        String expectedMessage = "0 person listed!";
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
@@ -66,6 +67,17 @@ public class FindCommandTest {
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
 
+    @Test
+    public void execute_zeroKeywords_onePersonFound() {
+        String expectedMessage = "1 person listed!";
+        NameContainsKeywordsPredicate predicate = preparePredicate("ALICE");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage,
+                false, false, false, false, false, true, false);
+        assertCommandSuccess(command, model, expectedCommandResult, expectedModel);
+        assertEquals(Arrays.asList(ALICE), model.getFilteredPersonList());
+    }
 
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {

--- a/src/test/java/seedu/address/logic/commands/FindTeamCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindTeamCommandTest.java
@@ -52,7 +52,7 @@ public class FindTeamCommandTest {
 
     @Test
     public void execute_zeroKeywords_noTeamFound() {
-        String expectedMessage = "0 teams listed!";
+        String expectedMessage = "0 team listed!";
         TeamContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindTeamCommand command = new FindTeamCommand(predicate);
         expectedModel.updateFilteredTeamList(predicate);
@@ -62,6 +62,17 @@ public class FindTeamCommandTest {
         assertEquals(Collections.emptyList(), model.getFilteredTeamList());
     }
 
+    @Test
+    public void execute_multipleKeywords_oneTeamsFound() {
+        String expectedMessage = "1 team listed!";
+        TeamContainsKeywordsPredicate predicate = preparePredicate("TEAM1");
+        FindTeamCommand command = new FindTeamCommand(predicate);
+        expectedModel.updateFilteredTeamList(predicate);
+        CommandResult expectedCommandResult = new CommandResult(expectedMessage,
+                false, false, false, false, false, false, true);
+        assertCommandSuccess(command, model, expectedCommandResult, expectedModel);
+        assertEquals(Arrays.asList(TEAM1), model.getFilteredTeamList());
+    }
     @Test
     public void execute_multipleKeywords_multipleTeamsFound() {
         String expectedMessage = "2 teams listed!";


### PR DESCRIPTION
This resolves the issue where the FindCommand and FindTeamCommand classes were outputting '1 persons' and '1 teams'. The output now correctly handles singular and plural nouns, ensuring grammatical accuracy