### PR TITLE
Bug fix: wrong reading information

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -116,13 +116,15 @@ class JsonAdaptedPerson {
                     String.format(MISSING_FIELD_MESSAGE_FORMAT, IdentityCode.class.getSimpleName()));
         }
 
+        final IdentityCode identityCode1 = new IdentityCode(identityCode);
+
         if (remark == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Remark.class.getSimpleName()));
         }
         final Remark modelRemark = new Remark(remark);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelRemark, modelTags);
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelRemark, modelTags, identityCode1);
     }
 
 }


### PR DESCRIPTION
The app will have a NullPointerException if we add the last person to a team and delete a person before him, then close the app and restart it. Person's Identity code will not be read correctly.

The exception will cause the whole app to crash.

Let's fix this bug by making the Persons' Identity codes be the same as what is stored in the file when reading information from the file.

In this way, there will not be a NullPointerException in this situation.